### PR TITLE
 Custom -> dostosowany

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,75 +11,75 @@ Bez ironii, bez korpomowy.
 Zachęcam do współudziału (ang. _contribution_).
 Znaczy [pull requestów](https://github.com/nurkiewicz/polski-w-it/pulls), nie tłumacząc na siłę.
 
-| angielski            | polskawy            | polski                                |
-| :------------------- | :------------------ | :------------------------------------ |
-| approve              | zaapruwować         | zaakceptować                          |
-| authentication       | autentykacja        | uwierzytelnienie (!)                  |
-| authorization        |                     | autoryzacja                           |
-| bug                  |                     | błąd                                  |
-| build                | zbildować           | zbudować                              |
-| button               |                     | przycisk, guzik                       |
-| cancel               | kanselować, anulacja| anulować                              |
-| case                 |                     | przypadek                             |
-| confirm              | konfirmować         | potwierdzić                           |
-| consistent           | konsystentny        | spójny                                |
-| content              |                     | zawartość, treść                      |
-| custom               | kastomowy           | specjalny, nietypowy, niestandardowy  |
-| default              | difoltowo           | domyślnie                             |
-| dependency           | dependencja         | zależność                             |
-| deploy               | zdiplojować         | wdrożyć                               |
-| developer            |                     | programista                           |
-| edge case            |                     | przypadek brzegowy                    |
-| event                |                     | zdarzenie, wydarzenie                 |
-| expire               | wyekspajerować      | wygasić                               |
-| feature              | ficzer              | funkcja                               |
-| feedback             |                     | informacja zwrotna                    |
-| fix                  | fiksnąć             | poprawić                              |
-| flow                 |                     | przepływ                              |
-| footer               |                     | stopka                                |
-| foreign key          |                     | klucz obcy                            |
-| header               |                     | nagłówek                              |
-| impact               |                     | wpływ                                 |
-| invalidate           | zinwalidować        | unieważnić                            |
-| issue                | isiu                | kwestia, problem                      |
-| job                  |                     | zadanie                               |
-| label                |                     | etykieta                              |
-| latency              |                     | opóźnienie                            |
-| launch               |                     | uruchomić, wprowadzić na rynek        |
-| layout               |                     | układ (np. elementów interfejsu)      |
-| lock                 | zalokować           | zablokować                            |
-| lunch                |                     | obiad, tyle że w Warszawie            |
-| meeting              |                     | spotkanie                             |
-| message              |                     | wiadomość                             |
-| mockup               |                     | makieta                               |
-| paging               | paginacja           | stronicowanie                         |
-| pattern              |                     | wzorzec                               |
-| plugin               |                     | wtyczka                               |
-| process              | procesować          | przetwarzać                           |
-| progress             |                     | postęp                                |
-| property             |                     | właściwość, opcja, cecha              |
-| random               | randomowy           | losowy, przypadkowy                   |
-| request              |                     | żądanie                               |
-| research             |                     | zbadać                                |
-| resource             |                     | zasób                                 |
-| response             |                     | odpowiedź                             |
-| review               | rewiułować          | przejrzeć                             |
-| rollback             |                     | wycofać, przywrócić                   |
-| sample               |                     | próbka, przykład                      |
-| save                 | (za)sejwować        | zapisać                               |
-| schedule             | zaskedżulować       | zaplanować                            |
-| service              |                     | usługa                                |
-| set (_cz._)          |                     | zbiór                                 |
-| set (_rz._)          | setować             | ustawiać                              |
-| setup (_cz._)        | zsetapować          | zestawić                              |
-| setup (_rz._)        |                     | konfiguracja                          |
-| support              | saportować          | wspierać                              |
-| task                 |                     | zadanie                               |
-| team                 |                     | zespół                                |
-| threshold            |                     | próg, poziom                          |
-| ticket               |                     | zadanie                               |
-| toggle               | togel               | przełącznik                           |
-| usability            |                     | użyteczność                           |
-| use case             |                     | przypadek użycia                      |
-| user                 |                     | użytkownik                            |
-| workaround           |                     | obejście                              |
+| angielski            | polskawy            | polski                                            |
+| :------------------- | :------------------ | :-----------------------------------------------  |
+| approve              | zaapruwować         | zaakceptować                                      |
+| authentication       | autentykacja        | uwierzytelnienie (!)                              |
+| authorization        |                     | autoryzacja                                       |
+| bug                  |                     | błąd                                              |
+| build                | zbildować           | zbudować                                          |
+| button               |                     | przycisk, guzik                                   |
+| cancel               | kanselować, anulacja| anulować                                          |
+| case                 |                     | przypadek                                         |
+| confirm              | konfirmować         | potwierdzić                                       |
+| consistent           | konsystentny        | spójny                                            |
+| content              |                     | zawartość, treść                                  |
+| custom               | kastomowy           | specjalny, nietypowy, niestandardowy, dostosowany |
+| default              | difoltowo           | domyślnie                                         |
+| dependency           | dependencja         | zależność                                         |
+| deploy               | zdiplojować         | wdrożyć                                           |
+| developer            |                     | programista                                       |
+| edge case            |                     | przypadek brzegowy                                |
+| event                |                     | zdarzenie, wydarzenie                             |
+| expire               | wyekspajerować      | wygasić                                           |
+| feature              | ficzer              | funkcja                                           |
+| feedback             |                     | informacja zwrotna                                |
+| fix                  | fiksnąć             | poprawić                                          |
+| flow                 |                     | przepływ                                          |
+| footer               |                     | stopka                                            |
+| foreign key          |                     | klucz obcy                                        |
+| header               |                     | nagłówek                                          |
+| impact               |                     | wpływ                                             |
+| invalidate           | zinwalidować        | unieważnić                                        |
+| issue                | isiu                | kwestia, problem                                  |
+| job                  |                     | zadanie                                           |
+| label                |                     | etykieta                                          |
+| latency              |                     | opóźnienie                                        |
+| launch               |                     | uruchomić, wprowadzić na rynek                    |
+| layout               |                     | układ (np. elementów interfejsu)                  |
+| lock                 | zalokować           | zablokować                                        |
+| lunch                |                     | obiad, tyle że w Warszawie                        |
+| meeting              |                     | spotkanie                                         |
+| message              |                     | wiadomość                                         |
+| mockup               |                     | makieta                                           |
+| paging               | paginacja           | stronicowanie                                     |
+| pattern              |                     | wzorzec                                           |
+| plugin               |                     | wtyczka                                           |
+| process              | procesować          | przetwarzać                                       |
+| progress             |                     | postęp                                            |
+| property             |                     | właściwość, opcja, cecha                          |
+| random               | randomowy           | losowy, przypadkowy                               |
+| request              |                     | żądanie                                           |
+| research             |                     | zbadać                                            |
+| resource             |                     | zasób                                             |
+| response             |                     | odpowiedź                                         |
+| review               | rewiułować          | przejrzeć                                         |
+| rollback             |                     | wycofać, przywrócić                               |
+| sample               |                     | próbka, przykład                                  |
+| save                 | (za)sejwować        | zapisać                                           |
+| schedule             | zaskedżulować       | zaplanować                                        |
+| service              |                     | usługa                                            |
+| set (_cz._)          |                     | zbiór                                             |
+| set (_rz._)          | setować             | ustawiać                                          |
+| setup (_cz._)        | zsetapować          | zestawić                                          |
+| setup (_rz._)        |                     | konfiguracja                                      |
+| support              | saportować          | wspierać                                          |
+| task                 |                     | zadanie                                           |
+| team                 |                     | zespół                                            |
+| threshold            |                     | próg, poziom                                      |
+| ticket               |                     | zadanie                                           |
+| toggle               | togel               | przełącznik                                       |
+| usability            |                     | użyteczność                                       |
+| use case             |                     | przypadek użycia                                  |
+| user                 |                     | użytkownik                                        |
+| workaround           |                     | obejście                                          |


### PR DESCRIPTION
Mamy customowy kod dla klienta.

Najczęstsze użycie tego słowa dotyczy dopasowania do potrzeb klienta. Nie standaryzacja, typowość, ale dostosowanie. 

        We have lots of customizations.
        Mamy dużo dostosowań.

        Yeah, it's a custom code.
        Tak, to dostosowany kod.

Wiem, że są już trzy tłumaczenia i każde z nich działa w pewnym kontekście. Ale w zdaniach powyżej nie pasuje nietypowy ani
niestandardowy (niestandardowy kod można zrozumieć na siłę). Owszem, _specjalny_ opisuje nietypowość tego przypadku również, ale nie fakt, że to jest kod spersonalizowany, dostosowany do potrzeb.

Jest dużo spacji (rozszerzam trzecią kolumnę), zatem sugeruję dodać ?w=1 do urla:
[https://github.com/nurkiewicz/polski-w-it/pull/34/files?w=1](https://github.com/nurkiewicz/polski-w-it/pull/34/files?w=1) 