### PR TITLE
Nieodpowiednie części mowy w 'zbiór' i 'zestawić'

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Znaczy [pull requestów](https://github.com/nurkiewicz/polski-w-it/pulls), nie t
 | save                 | (za)sejwować        | zapisać                               |
 | schedule             | zaskedżulować       | zaplanować                            |
 | service              |                     | usługa                                |
-| set (_n_)            | setować             | ustawiać                              |
-| set (_v_)            |                     | zbiór                                 |
+| set (_n_)            |                     | zbiór                                 |
+| set (_v_)            | setować             | ustawiać                              |
 | setup (_n_)          |                     | konfiguracja                          |
 | setup (_v_)          | zsetapować          | zestawić                              |
 | support              | saportować          | wspierać                              |


### PR DESCRIPTION
Zbiór to rzeczownik, ustawić - czasownik. Dla zachowania spójności zostawiłem kolejność w tabeli (najpierw rzeczownik, później czasownik). 