### PR TITLE
reactive -> reaktywny, reagujący

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Znaczy [pull requestów](https://github.com/nurkiewicz/polski-w-it/pulls), nie t
 | progress             |                     | postęp                                |
 | property             |                     | właściwość, opcja, cecha              |
 | random               | randomowy           | losowy, przypadkowy                   |
+| reactive             |                     | reaktywny, reagujący                  |
 | release (_n_)        |                     | wydanie, wersja                       |
 | release (_v_)        | rilisować           | wydawać nową wersję                   |
 | request              |                     | żądanie                               |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Znaczy [pull requestów](https://github.com/nurkiewicz/polski-w-it/pulls), nie t
 | progress             |                     | postęp                                |
 | property             |                     | właściwość, opcja, cecha              |
 | random               | randomowy           | losowy, przypadkowy                   |
-| reactive             |                     | reaktywny, reagujący                  |
+| reactive             |                     | reaktywny                             |
 | release (_n_)        |                     | wydanie, wersja                       |
 | release (_v_)        | rilisować           | wydawać nową wersję                   |
 | request              |                     | żądanie                               |


### PR DESCRIPTION
W związku z naszą rozmową na devdayu podrzucam propozycję tłumaczenia słowa reactive. Jako pierwsze stawiam reaktywny jako te powszechnie przez wszystkich używane, ale jako drugie `reagujący` które w moim odczuciu lepiej dla polskiego słuchacza oddaje znaczenie tego słowa.