### PR TITLE
Primary key -> klucz główny

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Znaczy [pull requestów](https://github.com/nurkiewicz/polski-w-it/pulls), nie t
 | plugin               |                     | wtyczka                               |
 | pointer              |                     | wskaźnik                              |
 | portable             |                     | przenośny                             |
-| primary key          |                     | klucz główny                          |
+| primary key          |                     | klucz podstawowy, klucz główny        |
 | process (_v_)        | procesować          | przetwarzać                           |
 | progress             |                     | postęp                                |
 | property             |                     | właściwość, opcja, cecha              |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Znaczy [pull requestów](https://github.com/nurkiewicz/polski-w-it/pulls), nie t
 | plugin               |                     | wtyczka                               |
 | pointer              |                     | wskaźnik                              |
 | portable             |                     | przenośny                             |
+| primary key          |                     | klucz główny                          |
 | process (_v_)        | procesować          | przetwarzać                           |
 | progress             |                     | postęp                                |
 | property             |                     | właściwość, opcja, cecha              |


### PR DESCRIPTION
Jak w tytule PR: tłumaczenie primary key na polskie "klucz główny"