### PR TITLE
support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -722,7 +722,7 @@ Jeśli musisz się zastanowić, jakie jest polskie tłumaczenie, danego pojęcia
 
 | support
 | saportować
-| (1) obsługiwać (2) wspierać
+| _(1)_ obsługiwać, _(2)_ wspierać
 
 | switch (_v_)
 | słiczować

--- a/README.adoc
+++ b/README.adoc
@@ -722,7 +722,7 @@ Jeśli musisz się zastanowić, jakie jest polskie tłumaczenie, danego pojęcia
 
 | support
 | saportować
-| wspierać
+| (1) obsługiwać (2) wspierać
 
 | switch (_v_)
 | słiczować

--- a/README.adoc
+++ b/README.adoc
@@ -16,6 +16,10 @@ Jeśli musisz się zastanowić, jakie jest polskie tłumaczenie, danego pojęcia
 |===
 | angielski | polskawy | polski
 
+| agents
+| agenci
+| agenty
+
 | agile (_a_)
 | edżajlowy
 | zwinny


### PR DESCRIPTION
_Wspierać_ znaczy tyle co _pomagać_, ew. _opierać_/_podtrzymywać_. W zdaniach typu "Linux does not support a newest drivers" albo "This website does not support Internet Explorer, please use a modern browser like Chrome or Edge", które często tłumaczone są jako "Linux nie wspiera najnowszych sterowników" albo "Ta strona nie wspiera Internet Explorera", zupełnie nie ma mowy o pomocy, tylko właśnie o obsłudze: "Linux nie obsługuje najnowszych sterowników", "Ta strona nie obsługuje Internet Explorera". Tak właściwie jedynym znanym mi przypadkiem poprawnego tłumaczenia _support_ jako _wsparcie_ jest _technical support_, które znaczy tyle co _pomoc techniczna_/_wsparcie techniczne_.
PS. Jakbym mógł, to bym w ogóle wywalił tłumaczenie nr 2, ale zdaję sobie sprawę że jest ono powszechne. Dlatego mój pomysł żeby promować tłumaczenie nr 1.