### PR TITLE
Schedule: noun (+ oznaczenie drugiej definicji jako verb)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -652,6 +652,10 @@ Jeśli musisz się zastanowić, jakie jest polskie tłumaczenie, danego pojęcia
 | (za)sejwować
 | zapisać
 
+| schedule (_n_)
+| 
+| harmonogram
+
 | schedule (_v_)
 | zaskedżulować
 | zaplanować

--- a/README.adoc
+++ b/README.adoc
@@ -652,7 +652,7 @@ Jeśli musisz się zastanowić, jakie jest polskie tłumaczenie, danego pojęcia
 | (za)sejwować
 | zapisać
 
-| schedule
+| schedule (_v_)
 | zaskedżulować
 | zaplanować
 


### PR DESCRIPTION
Dodałem _schedule_ w znaczeniu _harmonogram_. Definicję _schedule_ w znaczeniu czasownika oznaczyłem jako czasownik. 

*skedżul* jako polskawy odpowiednik nie wpisywałem, bo to w sumie to samo słowo co oryginał ¯\_(ツ)_/¯