### PR TITLE
Poprawne sortowanie w języku angielskim

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -540,10 +540,6 @@ Jeśli musisz się zastanowić, jakie jest polskie tłumaczenie, danego pojęcia
 |
 | wtyczka
 
-| proof of concept / poc
-|
-| prototyp
-
 | pointer
 |
 | wskaźnik
@@ -567,6 +563,10 @@ Jeśli musisz się zastanowić, jakie jest polskie tłumaczenie, danego pojęcia
 | progress
 |
 | postęp
+
+| proof of concept / poc
+|
+| prototyp
 
 | property
 | propercja


### PR DESCRIPTION
Poprawka sortowania terminów w języku angielskim - naprawia test `test_terms_are_sorted`